### PR TITLE
Remove PHPStan setting and improve related script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2",
         "overtrue/phplint": "^2",
-        "phpstan/phpstan": "0.*",
+        "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^8 || ^9",
         "slim/slim": "^4",
         "slim/psr7": "^1",
@@ -33,7 +33,7 @@
         "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --diff-format=udiff --config=.cs.php",
         "cs:fix": "php-cs-fixer fix --config=.cs.php",
         "lint": "phplint ./ --exclude=vendor --no-interaction --no-cache",
-        "phpstan": "phpstan analyse src tests --level=max -c phpstan.neon --no-progress --ansi",
+        "phpstan": "phpstan analyse -c phpstan.neon --no-progress --ansi",
         "sniffer:check": "phpcs --standard=phpcs.xml",
         "sniffer:fix": "phpcbf --standard=phpcs.xml",
         "test": "phpunit --configuration phpunit.xml --do-not-cache-result --colors=always",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+	level: max
+	paths:
+		- src
+		- tests


### PR DESCRIPTION
# Changed log

- Removing empty PHPStan configuration file and improve related script.
- The PHPStan will not report `phpstan.neon config file not found` issue now.