### PR TITLE
Add IgnoreErrors setting to ignore non-fixed error

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,6 @@ parameters:
 	paths:
 		- src
 		- tests
+	ignoreErrors:
+		- '#Parameter \#1 \$path of function dirname expects string, mixed given#'
+		- '#Parameter \#1 \$url of function parse_url expects string, mixed given#'


### PR DESCRIPTION
# Changed log

- Adding `ignoreErrors` setting on `phpstan.neon` file to ignore non-fixed errors.