### PR TITLE
Upgrade PHP-CS-Fixer to be 3.x version

### DIFF
--- a/.cs.php
+++ b/.cs.php
@@ -8,7 +8,7 @@ return (new PhpCsFixer\Config())
         '@PSR1' => true,
         '@PSR2' => true,
         '@Symfony' => true,
-        'psr4' => true,
+        'psr_autoloading' => true,
         // custom rules
         'align_multiline_comment' => ['comment_type' => 'phpdocs_only'], // psr-5
         'phpdoc_to_comment' => false,
@@ -21,7 +21,7 @@ return (new PhpCsFixer\Config())
         'declare_equal_normalize' => ['space' => 'single'],
         'increment_style' => ['style' => 'post'],
         'list_syntax' => ['syntax' => 'short'],
-        'no_short_echo_tag' => true,
+        'echo_tag_syntax' => ['format' => 'long'],
         'phpdoc_add_missing_param_annotation' => ['only_untyped' => false],
         'phpdoc_align' => false,
         'phpdoc_no_empty_return' => false,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "psr/http-server-middleware": "^1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2",
+        "friendsofphp/php-cs-fixer": "^3",
         "overtrue/phplint": "^2",
         "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^8 || ^9",
@@ -30,7 +30,7 @@
             "@phpstan",
             "@test:coverage"
         ],
-        "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --diff-format=udiff --config=.cs.php",
+        "cs:check": "php-cs-fixer fix --dry-run --format=txt --verbose --diff --config=.cs.php",
         "cs:fix": "php-cs-fixer fix --config=.cs.php",
         "lint": "phplint ./ --exclude=vendor --no-interaction --no-cache",
         "phpstan": "phpstan analyse -c phpstan.neon --no-progress --ansi",


### PR DESCRIPTION
# Changed log

- Upgrading the `PHP-CS-Fixer` to be `3.x` version.
- Modifying the `.cs.php` file to be compatible with `PHP-CS-Fixer` `3.x` version.