### PR TITLE
PHP8.4 support. PHP Deprecated: Implicitly marking parameter as nulla…

### DIFF
--- a/src/BasePathDetector.php
+++ b/src/BasePathDetector.php
@@ -23,7 +23,7 @@ class BasePathDetector
      * @param array<mixed> $server The SERVER data to use
      * @param string|null $phpSapi The PHP_SAPI value
      */
-    public function __construct(array $server, string $phpSapi = null)
+    public function __construct(array $server, ?string $phpSapi = null)
     {
         $this->server = $server;
         $this->phpSapi = $phpSapi ?? PHP_SAPI;

--- a/src/BasePathMiddleware.php
+++ b/src/BasePathMiddleware.php
@@ -29,7 +29,7 @@ final class BasePathMiddleware implements MiddlewareInterface
      * @param App $app The slim app
      * @param string|null $phpSapi The PHP_SAPI value
      */
-    public function __construct(App $app, string $phpSapi = null)
+    public function __construct(App $app, ?string $phpSapi = null)
     {
         $this->app = $app;
         $this->phpSapi = $phpSapi;


### PR DESCRIPTION
…ble is deprecated.

Hello!

I came across this error message today:
**PHP Deprecated: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead.**

I’ve fixed it and would like to contribute to the project.

Kind regards,
Heinrich Schiller